### PR TITLE
Move tagLocationHook to in-function static.

### DIFF
--- a/mlir/include/mlir/IR/Operation.h
+++ b/mlir/include/mlir/IR/Operation.h
@@ -29,11 +29,18 @@ class alignas(8) Operation final
     : public llvm::ilist_node_with_parent<Operation, Block>,
       private llvm::TrailingObjects<Operation, detail::OperandStorage,
                                     BlockOperand, Region, OpOperand> {
-    static std::function<Location(Location)> tagLocationHook;
+  static std::function<Location(Location)> & getTagLocationHookSingleton(){
+    static std::function<Location(Location)> tagLocationHook = std::function<Location(Location)>();
+    return tagLocationHook;
+  }
 public:
   static void setTagLocationHook(std::function<Location(Location)> hook){
-    tagLocationHook=hook;
+    getTagLocationHookSingleton() = hook;
   }
+  static std::function<Location(Location)> getTagLocationHook(){
+    return getTagLocationHookSingleton();
+  }
+
   /// Create a new Operation with the specific fields.
   static Operation *create(Location location, OperationName name,
                            TypeRange resultTypes, ValueRange operands,

--- a/mlir/lib/IR/Operation.cpp
+++ b/mlir/lib/IR/Operation.cpp
@@ -17,8 +17,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include <numeric>
 
-using namespace mlir;
-std::function<Location(Location)> Operation::tagLocationHook=std::function<Location(Location)>();
+using namespace mlir;;
 
 //===----------------------------------------------------------------------===//
 // Operation
@@ -88,8 +87,8 @@ Operation *Operation::create(Location location, OperationName name,
   char *mallocMem = reinterpret_cast<char *>(malloc(byteSize + prefixByteSize));
   void *rawMem = mallocMem + prefixByteSize;
 
-  if(tagLocationHook){
-    location = tagLocationHook(location);
+  if(getTagLocationHook()){
+    location = getTagLocationHook()(location);
   }
 
   // Create the new Operation.


### PR DESCRIPTION
Global statics have undefined initialization order, and compiling with Clang 14 raises a warning accordingly (which prevents compilation due to -Werror). This PR uses a private function with an in-function static instead.